### PR TITLE
Feature/auto scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,21 @@ grunt karma
         <td>default: 200</td>
     </tr>
     <tr>
+        <td>auto</td>
+        <td>start scrolling automatically</td>
+        <td>default: false</td>
+    </tr>
+    <tr>
+        <td>autoDelay</td>
+        <td>time in milliseconds between each automatic scroll</td>
+        <td>default: 3000</td>
+    </tr>
+    <tr>
+        <td>autoDirection</td>
+        <td>the direction for each automatic scroll</td>
+        <td>default: 'next'</td>
+    </tr>
+    <tr>
         <td>ease</td>
         <td>cubic bezier easing functions: http://easings.net/de</td>
         <td>default: 'ease'</td>

--- a/demo/app.css
+++ b/demo/app.css
@@ -222,7 +222,7 @@ footer {
 
 }
 
-.multipleelements li, .multislides li, .ease li {
+.multipleelements li, .multislides li, .auto li, .ease li {
     width: 60px;
     margin-right: 10px;
 }
@@ -233,6 +233,7 @@ footer {
 .variablewidth li:last-child,
 .multipleelements li:last-child,
 .multislides li:last-child,
+.auto li:last-child,
 .ease li:last-child {
     margin-right: 0;
 }
@@ -317,7 +318,7 @@ footer {
         margin-right: 10px;
     }
 
-    .multipleelements li, .multislides li, .ease li {
+    .multipleelements li, .multislides li, .auto li, .ease li {
         width: 130px;
         margin-right: 20px;
     }
@@ -357,7 +358,7 @@ footer {
         margin-right: 10px;
     }
 
-    .multipleelements li, .multislides li, .ease li {
+    .multipleelements li, .multislides li, .auto li, .ease li {
         width: 205px;
         margin-right: 20px;
     }

--- a/demo/app.css
+++ b/demo/app.css
@@ -222,7 +222,7 @@ footer {
 
 }
 
-.multipleelements li, .multislides li, .auto li, .ease li {
+.multipleelements li, .multislides li, .ease li {
     width: 60px;
     margin-right: 10px;
 }
@@ -233,7 +233,6 @@ footer {
 .variablewidth li:last-child,
 .multipleelements li:last-child,
 .multislides li:last-child,
-.auto li:last-child,
 .ease li:last-child {
     margin-right: 0;
 }
@@ -318,7 +317,7 @@ footer {
         margin-right: 10px;
     }
 
-    .multipleelements li, .multislides li, .auto li, .ease li {
+    .multipleelements li, .multislides li, .ease li {
         width: 130px;
         margin-right: 20px;
     }
@@ -358,7 +357,7 @@ footer {
         margin-right: 10px;
     }
 
-    .multipleelements li, .multislides li, .auto li, .ease li {
+    .multipleelements li, .multislides li, .ease li {
         width: 205px;
         margin-right: 20px;
     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -291,6 +291,47 @@
 
 </code></pre></div>
 
+            <h2>Automatic Scrolling</h2>
+
+            <div class="slider js_auto auto">
+                <div class="frame js_frame">
+                    <ul class="slides js_slides">
+                        <li class="js_slide">1</li>
+                        <li class="js_slide">2</li>
+                        <li class="js_slide">3</li>
+                        <li class="js_slide">4</li>
+                        <li class="js_slide">5</li>
+                        <li class="js_slide">6</li>
+                        <li class="js_slide">7</li>
+                        <li class="js_slide">8</li>
+                        <li class="js_slide">9</li>
+                        <li class="js_slide">10</li>
+                        <li class="js_slide">11</li>
+                        <li class="js_slide">12</li>
+                    </ul>
+                </div>
+
+                <span class="js_prev prev">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 501.5 501.5"><g><path fill="#2E435A" d="M302.67 90.877l55.77 55.508L254.575 250.75 358.44 355.116l-55.77 55.506L143.56 250.75z"/></g></svg>
+                </span>
+
+                <span class="js_next next">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 501.5 501.5"><g><path fill="#2E435A" d="M199.33 410.622l-55.77-55.508L247.425 250.75 143.56 146.384l55.77-55.507L358.44 250.75z"/></g></svg>
+                </span>
+            </div>
+
+<div class="examplecode"><pre><code class="javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+        var auto = document.querySelector('.js_auto');
+
+        lory(auto, {
+            infinite: 4,
+            auto: true
+        });
+    });
+
+</code></pre></div>
+
             <h2>Custom easings</h2>
 
             <div class="slider js_ease ease">
@@ -633,6 +674,7 @@
             var rewind_percentage = document.querySelector('.js_rewind_percentage');
             var variableWidth    = document.querySelector('.js_variablewidth');
             var multiSlides      = document.querySelector('.js_multislides');
+            var auto             = document.querySelector('.js_auto');
             var ease             = document.querySelector('.js_ease');
             var events           = document.querySelector('.js_events');
 
@@ -659,6 +701,11 @@
             lory(multiSlides, {
                 infinite: 4,
                 slidesToScroll: 4
+            });
+
+            lory(auto, {
+                infinite: 4,
+                auto: true
             });
 
             lory(ease, {

--- a/demo/index.html
+++ b/demo/index.html
@@ -293,7 +293,7 @@
 
             <h2>Automatic Scrolling</h2>
 
-            <div class="slider js_auto auto">
+            <div class="slider js_auto multislides">
                 <div class="frame js_frame">
                     <ul class="slides js_slides">
                         <li class="js_slide">1</li>

--- a/src/lory.js
+++ b/src/lory.js
@@ -293,6 +293,8 @@ var lory = function (slider, opts) {
 
     /**
      * setupAutomaticScrolling: function to setup if auto is set
+     *
+     * @param  {element} slider
      */
     var setupAutomaticScrolling = function (slider) {
         if (options.autoDirection === 'prev') {

--- a/src/lory.js
+++ b/src/lory.js
@@ -189,6 +189,24 @@ var lory = function (slider, opts) {
         snapBackSpeed: 200,
 
         /**
+         * start scrolling automatically
+         * @auto {Boolean}
+         */
+        auto: false,
+
+        /**
+         * time in milliseconds between each automatic scroll
+         * @autoDelay {Number}
+         */
+        autoDelay: 3000,
+
+        /**
+         * the name of the direction for each automatic scroll
+         * @autoDirection {String}
+         */
+        autoDirection: 'next',
+
+        /**
          * Basic easing functions: https://developer.mozilla.org/de/docs/Web/CSS/transition-timing-function
          * cubic bezier easing functions: http://easings.net/de
          * @ease {String}
@@ -262,6 +280,31 @@ var lory = function (slider, opts) {
         return slice.call(slideContainer.children);
     };
 
+    var timeout;
+
+    var autoStart = function () {
+        clearTimeout(timeout);
+        timeout = setTimeout(options.autoDirection, options.autoDelay);
+    };
+
+    var autoStop = function () {
+        clearTimeout(timeout);
+    };
+
+    /**
+     * setupAutomaticScrolling: function to setup if auto is set
+     */
+    var setupAutomaticScrolling = function (slider) {
+        if (options.autoDirection === 'prev') {
+            options.autoDirection = prev;
+        } else {
+            options.autoDirection = next;
+        }
+        slider.addEventListener('after.lory.init', autoStart);
+        slider.addEventListener('after.lory.slide', autoStart);
+        slider.addEventListener('on.lory.destroy', autoStop);
+    };
+
     /**
      * public
      * setup function
@@ -291,6 +334,10 @@ var lory = function (slider, opts) {
         }
 
         reset();
+
+        if (options.auto) {
+            setupAutomaticScrolling(slider);
+        }
 
         if (prevCtrl && nextCtrl) {
             prevCtrl.addEventListener('click', prev);

--- a/src/lory.js
+++ b/src/lory.js
@@ -282,28 +282,32 @@ var lory = function (slider, opts) {
 
     var timeout;
 
-    var autoStart = function () {
+    /**
+     * autoMove: move in the specified direction after the specified delay
+     */
+    var autoMove = function () {
         clearTimeout(timeout);
         timeout = setTimeout(options.autoDirection, options.autoDelay);
     };
 
+    /**
+     * autoStop: clear scheduled movements
+     */
     var autoStop = function () {
         clearTimeout(timeout);
     };
 
     /**
      * setupAutomaticScrolling: function to setup if auto is set
-     *
-     * @param  {element} slider
      */
-    var setupAutomaticScrolling = function (slider) {
+    var setupAutomaticScrolling = function () {
         if (options.autoDirection === 'prev') {
             options.autoDirection = prev;
         } else {
             options.autoDirection = next;
         }
-        slider.addEventListener('after.lory.init', autoStart);
-        slider.addEventListener('after.lory.slide', autoStart);
+        slider.addEventListener('after.lory.init', autoMove);
+        slider.addEventListener('after.lory.slide', autoMove);
         slider.addEventListener('on.lory.destroy', autoStop);
     };
 
@@ -338,7 +342,7 @@ var lory = function (slider, opts) {
         reset();
 
         if (options.auto) {
-            setupAutomaticScrolling(slider);
+            setupAutomaticScrolling();
         }
 
         if (prevCtrl && nextCtrl) {


### PR DESCRIPTION
I created this branch to address issue #42.

It adds three new options with sensible defaults, auto, autoDelay, and autoDirection. The auto option defaults to false, so all existing sliders continue to have the same behavior. If a new slider is created with the auto option set to true then a timeout is set to scroll to the next (or previous) slide in 3 seconds. The delay of 3 seconds can be changed with the autoDelay option and the direction of next or previous can be changed with the autoDirection option.

I tried to follow your style guidelines, but do let me know if there's any changes you'd like to see.