### PR TITLE
fix(package.json): Export unminified script in main

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jQuery",
     "mobile"
   ],
-  "main": "./dist/lory.min.js",
+  "main": "./dist/lory.js",
   "devDependencies": {
     "babel-core": "5.8.25",
     "babel-loader": "5.3.2",


### PR DESCRIPTION
Export the unminified version in the package.json's main field to make
it easier to debug when used with a module bundler.