### PR TITLE
feat(package.json): Expose source via jsnext:main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jQuery",
     "mobile"
   ],
-  "main": "./dist/lory.min.js",
+  "main": "./dist/lory.js",
   "devDependencies": {
     "babel-core": "5.8.25",
     "babel-loader": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mobile"
   ],
   "main": "./dist/lory.js",
+  "jsnext:main": "./src/lory.js",
   "devDependencies": {
     "babel-core": "5.8.25",
     "babel-loader": "5.3.2",


### PR DESCRIPTION
Expose the source code via "jsnext:main" field in package.json so that
other tools can use the actual source code instead of the bundled code.
More information at: https://github.com/rollup/rollup/wiki/jsnext:main