### PR TITLE
chore(package.json): add "save-exact" option to npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true


### PR DESCRIPTION
Add a .npmrc file to specify default options for npm.
By specifying "save-exact" all dependencies installed via npm will
always be saved with their exact version number which prevents future
breakage when other package maintainers make mistakes with their
versioning schema.