### PR TITLE
fix: detect last slide by index instead of by offset

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -178,7 +178,7 @@ export function lory (slider, opts) {
             index = nextIndex;
         }
 
-        if (infinite && (Math.abs(nextOffset) === maxOffset || Math.abs(nextOffset) === 0)) {
+        if (infinite && (nextIndex === slides.length - infinite || nextIndex === 0)) {
             if (direction) {
                 index = infinite;
             }


### PR DESCRIPTION
This should be a more robust method to detect if we need to wrap around.