### PR TITLE
Add option to not slide to first index on page resize

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -89,7 +89,7 @@ export default {
 
     /**
      * If false, slides lory to the first slide on window resize.
-     * @persistIndex {boolean}
+     * @rewindOnResize {boolean}
      */
     rewindOnResize: false
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -91,5 +91,5 @@ export default {
      * If false, slides lory to the first slide on window resize.
      * @persistIndex {boolean}
      */
-    persistIndex: true
+    rewindOnResize: false
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -85,5 +85,11 @@ export default {
      * window instance
      * @window {object}
      */
-    window: window
+    window: window,
+
+    /**
+     * If false, slides lory to the first slide on window resize.
+     * @persistIndex {boolean}
+     */
+    persistIndex: true
 };

--- a/src/lory.js
+++ b/src/lory.js
@@ -266,7 +266,7 @@ export function lory (slider, opts) {
      * reset function: called on resize
      */
     function reset () {
-        var {infinite, ease, rewindSpeed, persistIndex} = options;
+        var {infinite, ease, rewindSpeed, rewindOnResize} = options;
 
         slidesWidth = slideContainer.getBoundingClientRect()
             .width || slideContainer.offsetWidth;
@@ -279,7 +279,7 @@ export function lory (slider, opts) {
             }, 0);
         }
 
-        if (!persistIndex) {
+        if (!rewindOnResize) {
             index = 0;
         } else {
             ease = null;

--- a/src/lory.js
+++ b/src/lory.js
@@ -266,7 +266,7 @@ export function lory (slider, opts) {
      * reset function: called on resize
      */
     function reset () {
-        const {infinite, ease, rewindSpeed} = options;
+        const {infinite, ease, rewindSpeed, persistIndex} = options;
 
         slidesWidth = slideContainer.getBoundingClientRect()
             .width || slideContainer.offsetWidth;
@@ -279,7 +279,10 @@ export function lory (slider, opts) {
             }, 0);
         }
 
-        index = 0;
+        if (!persistIndex) {
+            index = 0;
+        }
+
 
         if (infinite) {
             translate(slides[index + infinite].offsetLeft * -1, 0, null);

--- a/src/lory.js
+++ b/src/lory.js
@@ -266,7 +266,7 @@ export function lory (slider, opts) {
      * reset function: called on resize
      */
     function reset () {
-        const {infinite, ease, rewindSpeed, persistIndex} = options;
+        var {infinite, ease, rewindSpeed, persistIndex} = options;
 
         slidesWidth = slideContainer.getBoundingClientRect()
             .width || slideContainer.offsetWidth;
@@ -281,8 +281,10 @@ export function lory (slider, opts) {
 
         if (!persistIndex) {
             index = 0;
+        } else {
+            ease = null;
+            rewindSpeed = 0;
         }
-
 
         if (infinite) {
             translate(slides[index + infinite].offsetLeft * -1, 0, null);
@@ -290,7 +292,8 @@ export function lory (slider, opts) {
             index = index + infinite;
             position.x = slides[index].offsetLeft * -1;
         } else {
-            translate(0, rewindSpeed, ease);
+            translate(slides[index].offsetLeft * -1, rewindSpeed, ease);
+            position.x = slides[index].offsetLeft * -1;
         }
     }
 


### PR DESCRIPTION
fixes #237

Right now it's defaulted to persist the index on resize, can be changed easily. 