### PR TITLE
fix: current slide was also counting the duplicated slides...

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -199,7 +199,7 @@ export function lory (slider, opts) {
         }
 
         dispatchSliderEvent('after', 'slide', {
-            currentSlide: index
+            currentSlide: infinite ? index - 1 : index
         });
     }
 


### PR DESCRIPTION
... that are created for infinite sliders.

When trying to get the current slide on after.lory.slide by using event.detail.currentSlide the normal slider gives out the value 0 on the first slide but when it is a infinit slider it gives out the value 1.
