### PR TITLE
Delay, dom setup till next js frame

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -241,9 +241,7 @@ export function lory (slider, opts) {
         // There is a race here, and when called size of elements is
         // still not initialized, we can delay reset execution, till
         // js next frame. (This will ensure, that size is ready for checking)
-        setTimeout(()=>{
-            reset();
-        }, 0);
+        setTimeout(reset, 0);
 
         if (classNameActiveSlide) {
             setActiveElement(slides, index);

--- a/src/lory.js
+++ b/src/lory.js
@@ -238,7 +238,12 @@ export function lory (slider, opts) {
             slides = slice.call(slideContainer.children);
         }
 
-        reset();
+        // There is a race here, and when called size of elements is
+        // still not initialized, we can delay reset execution, till
+        // js next frame. (This will ensure, that size is ready for checking)
+        setTimeout(()=>{
+            reset();
+        }, 0);
 
         if (classNameActiveSlide) {
             setActiveElement(slides, index);


### PR DESCRIPTION
After some debug, found the issue, that makes lory inusable. (under specific conditions)
Seems like, on reset() you are setting up size of the main frame. (But when is called during setup()) it is not correctly initized, and gots a 0 value. (Width values are 0)). Then you have some workarounds inside code (calling reset again) but there are cases, where reset is not called, and the component is unusable.

I think that with this patch some of the issues on the main repo can be solved, at least some of them related to the same behaviour.

 