### PR TITLE
fix: #328 infinite with slidesToScroll > 1 is broken

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -140,9 +140,17 @@ export function lory (slider, opts) {
 
         if (typeof nextIndex !== 'number') {
             if (direction) {
-                nextIndex = index + slidesToScroll;
+              if (infinite && index + (infinite * 2) !== slides.length) {
+                  nextIndex = index + (infinite - index % infinite);
+              } else {
+                  nextIndex = index + slidesToScroll;
+              }
             } else {
-                nextIndex = index - slidesToScroll;
+              if (infinite && index % infinite !== 0) {
+                  nextIndex = index - index % infinite;
+              } else {
+                  nextIndex = index - slidesToScroll;
+              }
             }
         }
 
@@ -178,7 +186,8 @@ export function lory (slider, opts) {
             index = nextIndex;
         }
 
-        if (infinite && (nextIndex === slides.length - infinite || nextIndex === 0)) {
+        if (infinite && (nextIndex === slides.length - infinite ||
+            nextIndex === slides.length - slides.length % infinite || nextIndex === 0)) {
             if (direction) {
                 index = infinite;
             }


### PR DESCRIPTION
Here is a possible solution to the issue of having infinite and slidesToScroll > 1 where slides.length % infinite != 0

The first section of changes always keeps the nextIndex a perfect mod of the infinite value.
Say the infinite and slidesToScroll are set to 4 and there are 9 slides this could create a scenario where only 1 slide scrolls on next or prev, but this way it preserves the first slide, and keeps the slides more consistently placed.

The second section adds a check for hitting the end of the slides, and resetting the index if  slides.length % infinite != 0