### PR TITLE
Add option 'initialIndex'

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,11 @@ li {
         <td>default: 'ease'</td>
     </tr>
     <tr>
+        <td>initialIndex</td>
+        <td>the slide index to show when the slider is initialized</td>
+        <td>default: 0</td>
+    </tr>
+    <tr>
         <td>classNameFrame</td>
         <td>class name for slider frame</td>
         <td>default: 'js_frame'</td>

--- a/index.html
+++ b/index.html
@@ -699,6 +699,11 @@
                     <td>default: 200</td>
                 </tr>
                 <tr>
+                    <td>initialIndex</td>
+                    <td>the slide index to show when the slider is initialized</td>
+                    <td>default: 0</td>
+                </tr>
+                <tr>
                     <th>ease</th>
                     <td>cubic bezier easing functions: http://easings.net/de</td>
                     <td>default: 'ease'</td>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -45,6 +45,12 @@ export default {
     infinite: false,
 
     /**
+     * the slide index to show when the slider is initialized.
+     * @initialIndex {number}
+     */
+    initialIndex: 0,
+
+    /**
      * class name for slider frame
      * @classNameFrame {string}
      */

--- a/src/lory.js
+++ b/src/lory.js
@@ -219,9 +219,11 @@ export function lory (slider, opts) {
             classNamePrevCtrl,
             classNameNextCtrl,
             enableMouseEvents,
-            classNameActiveSlide
+            classNameActiveSlide,
+            initialIndex
         } = options;
 
+        index = initialIndex;
         frame = slider.getElementsByClassName(classNameFrame)[0];
         slideContainer = frame.getElementsByClassName(classNameSlideContainer)[0];
         prevCtrl = slider.getElementsByClassName(classNamePrevCtrl)[0];
@@ -266,7 +268,7 @@ export function lory (slider, opts) {
      * reset function: called on resize
      */
     function reset () {
-        var {infinite, ease, rewindSpeed, rewindOnResize, classNameActiveSlide} = options;
+        var {infinite, ease, rewindSpeed, rewindOnResize, classNameActiveSlide, initialIndex} = options;
 
         slidesWidth = slideContainer.getBoundingClientRect()
             .width || slideContainer.offsetWidth;
@@ -280,7 +282,7 @@ export function lory (slider, opts) {
         }
 
         if (rewindOnResize) {
-            index = 0;
+            index = initialIndex;
         } else {
             ease = null;
             rewindSpeed = 0;

--- a/test/lory.test.js
+++ b/test/lory.test.js
@@ -335,6 +335,26 @@ describe('lory()', function () {
                 });
             });
         });
+
+        describe('with initialIndex', function () {
+            beforeEach(function () {
+                instance = lory(element, {
+                    initialIndex: 3
+                });
+            });
+
+            describe('called once', function() {
+                var expectedIndex = 2;
+
+                beforeEach(function () {
+                    instance.prev();
+                });
+
+                it('index has to be 2 (one less than initialIndex)', function() {
+                    assert.equal(instance.returnIndex(), expectedIndex);
+                });
+             });
+         });
     });
 
     describe('.destroy()', function () {


### PR DESCRIPTION
This allows the user to specify an initial slide that should display when lory is first initialized.

As far as I'm aware, there is currently no other way to do this. Please let me know if I missed anything! Thanks :)

Closes https://github.com/meandmax/lory/issues/628