### PR TITLE
Revert "feat(package.json): Expose source via jsnext:main field"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "mobile"
   ],
   "main": "./dist/lory.js",
-  "jsnext:main": "./src/lory.js",
   "devDependencies": {
     "babel-cli": "6.22.2",
     "babel-core": "6.21.0",


### PR DESCRIPTION
`./src/lory.js` contains ES6/ES7 code, which is not what `jsnext:main` is for. If people want to use Lory's pre-transpiled source then they should import `./src/lory.js` directly.

https://github.com/rollup/rollup/wiki/pkg.module