### PR TITLE
Make download button on website actually download.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <p class="description">Written in ecmascript 6</p>
         <p class="description">Using webpack, babel & eslint for development</p>
 
-        <a class="dist" href="./dist/lory.min.js">Download Here</a>
+        <a class="dist" href="./dist/lory.min.js" download>Download Here</a>
 
         <section class="prerequisited">
             <div class="examplecode">


### PR DESCRIPTION
Add the `download` attribute to the "Download Here" button so that modern browsers actually download the file instead of just displaying it. Closes #634.