### PR TITLE
Added dynamic classes to previous and next controls

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -262,6 +262,10 @@ export function lory (slider, opts) {
             if (prevCtrl) {
                 prevCtrl.classList.add('disabled');
             }
+
+            if (nextCtrl && (slides.length === 1)) {
+                nextCtrl.classList.add('disabled');
+            }
         }
 
         reset();

--- a/src/lory.js
+++ b/src/lory.js
@@ -138,6 +138,16 @@ export function lory (slider, opts) {
             nextSlide
         });
 
+        /**
+         * Reset control classes
+         */
+        if (prevCtrl) {
+            prevCtrl.classList.remove('disabled');
+        }
+        if (nextCtrl) {
+            nextCtrl.classList.remove('disabled');
+        }
+
         if (typeof nextIndex !== 'number') {
             if (direction) {
                 nextIndex = index + slidesToScroll;
@@ -198,6 +208,18 @@ export function lory (slider, opts) {
             setActiveElement(slice.call(slides), index);
         }
 
+        /**
+         * update classes for next and prev arrows
+         * based on user settings
+         */
+        if (prevCtrl && !infinite && nextIndex === 0) {
+            prevCtrl.classList.add('disabled');
+        }
+
+        if (nextCtrl && !infinite && !rewind && ((nextIndex + 1) === slides.length)) {
+            nextCtrl.classList.add('disabled');
+        }
+
         dispatchSliderEvent('after', 'slide', {
             currentSlide: index
         });
@@ -236,6 +258,10 @@ export function lory (slider, opts) {
             slides = setupInfinite(slice.call(slideContainer.children));
         } else {
             slides = slice.call(slideContainer.children);
+            
+            if (prevCtrl) {
+                prevCtrl.classList.add('disabled');
+            }
         }
 
         reset();

--- a/src/lory.js
+++ b/src/lory.js
@@ -263,7 +263,7 @@ export function lory (slider, opts) {
                 prevCtrl.classList.add('disabled');
             }
 
-            if (nextCtrl && (slides.length === 1)) {
+            if (nextCtrl && (slides.length === 1) && !options.rewind) {
                 nextCtrl.classList.add('disabled');
             }
         }

--- a/static/app.css
+++ b/static/app.css
@@ -278,8 +278,19 @@ footer {
     left: 0;
 }
 
+.next.disabled,
+.prev.disabled {
+    opacity: .3;
+    pointer-events: none;
+}
+
 .next svg, .prev svg {
     width: 25px;
+    transition: .4s;
+}
+
+.next svg:hover, .prev svg:hover {
+    transform: scale(1.1);
 }
 
 .events_log {


### PR DESCRIPTION
When a previous or next control takes no action (for example, the previous control at the beginning of a non-infinite carousel or the next control at the end of a non-infinite and non-rewinding carousel), a class of 'disabled' is added to it.

Also added minor style updates for next and previous controls for their disabled and hovered states.