### PR TITLE
Update use example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
             <h2>Prerequisited Html structure<br><small><em>Class names can be changed through options</em></small></h2>
 
             <pre><code class="html">
-            &lt;div class=&quot;slider js_slider&quot;&gt;
+            &lt;div class=&quot;slider js_simple js_slider&quot;&gt;
                 &lt;div class=&quot;frame js_frame&quot;&gt;
                     &lt;ul class=&quot;slides js_slides&quot;&gt;
                         &lt;li class=&quot;js_slide&quot;&gt;1&lt;/li&gt;


### PR DESCRIPTION
Hi guys,
I found a error a html structure of example. On structure of example does not contain the class `.js simple` thats referenced of javascript example.
> Before
```html
<div class="slider js_slider">
```
> After
```html
<div class="slider js_simple js_slider">
```
> Example JavaScript
```javascript
var simple = document.querySelector('.js_simple');
```