### PR TITLE
Feature Add: Auto Next slide

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -97,5 +97,13 @@ export default {
      * If false, slides lory to the first slide on window resize.
      * @rewindOnResize {boolean}
      */
-    rewindOnResize: true
+    rewindOnResize: true,
+
+    /**
+     * Enables auto slideshow
+     * @autoMode {object}
+     * @autoMode.enabled {boolean}
+     * @autoMode.interval {number}
+     */
+    autoMode: { enabled: false, interval: 3000 }
 };


### PR DESCRIPTION
Added autoMode object option to allow automatically going to the next
slide.

Testing hasn’t been done outside of my requirement - auto next with
infinite = 1 - but looking at the code it shouldn’t break anything else
as its just automatically calling next function. 