### PR TITLE
Prev button should't be disabled if initialIndex is not 0.

### DIFF
--- a/src/lory.js
+++ b/src/lory.js
@@ -284,7 +284,7 @@ export function lory (slider, opts) {
         } else {
             slides = slice.call(slideContainer.children);
 
-            if (prevCtrl && !options.rewindPrev) {
+            if (prevCtrl && !options.rewindPrev && options.initialIndex === 0) {
                 prevCtrl.classList.add(classNameDisabledPrevCtrl);
             }
 


### PR DESCRIPTION
Prev button should't be disabled on setup if initialIndex is not 0.